### PR TITLE
Fixes with the hardcoding and Get-YamlStream

### DIFF
--- a/Functions/YamlDotNet-Integration.ps1
+++ b/Functions/YamlDotNet-Integration.ps1
@@ -11,12 +11,13 @@ function Get-YamlStream([string] $file) {
 
     $yamlStream.Load([System.IO.TextReader] $streamReader)
     $streamReader.Close()
-    return $yamlStream
+    $Hash = @{YamlStream=$yamlStream}
+    return $Hash
 }
 
 function Get-YamlDocument([string] $file) {
     $yamlStream = Get-YamlStream $file
-    $document = $yamlStream.Documents[0]
+    $document = $yamlStream.YamlStream.Documents[0]
     return $document
 }
 
@@ -26,7 +27,7 @@ function Get-YamlDocumentFromString([string] $yamlString) {
     $yamlStream.Load([System.IO.TextReader] $stringReader)
 
     $document = $yamlStream.Documents[0]
-    return $document
+    return $documen
 }
 
 function Explode-Node($node) {

--- a/PowerYaml.psm1
+++ b/PowerYaml.psm1
@@ -128,6 +128,7 @@ function Export-Yaml {
 		}
 	}
 }
-Add-Type -Path "C:\Users\chunt\Documents\GitHub\YamlDotNet\YamlDotNet.Configuration\bin\Debug\YamlDotNet.RepresentationModel.dll"
+#Add-Type -Path "C:\Users\chunt\Documents\GitHub\YamlDotNet\YamlDotNet.Configuration\bin\Debug\YamlDotNet.RepresentationModel.dll"
+Add-Type -Path "$PSScriptRoot\Libs\YamlDotNet.RepresentationModel.dll"
 #Load-YamlDotNetLibraries (Join-Path $PSScriptRoot -ChildPath "Libs")
 Export-ModuleMember -Function Get-Yaml, Import-Yaml, Export-Yaml


### PR DESCRIPTION
I was trying the PowerYaml today and came across two issues. One is with the DLL hardcoding in PowerYaml.psm1 and another is with the Get-YamlStream function (details in the commits).
